### PR TITLE
Procesado rss DOM

### DIFF
--- a/rss-dom/MGGomez/.gitignore
+++ b/rss-dom/MGGomez/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+/target
+/out

--- a/rss-dom/MGGomez/src/main/java/Documento.java
+++ b/rss-dom/MGGomez/src/main/java/Documento.java
@@ -1,0 +1,45 @@
+
+import org.w3c.dom.*;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+
+public class Documento {
+
+    public void leerDocumento() {
+        File file = new File("C:\\Users\\Mario\\Desktop\\titulares.xml");
+
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(file);
+            doc.normalize();
+            NodeList nList = doc.getElementsByTagName("item");
+            System.out.println("El número de noticias total es de " + nList.getLength());
+            System.out.println("Fecha de la publicación: " + doc.getElementsByTagName("pubDate").item(0).getTextContent() + "\n\n");
+            for (int i = 0; i < nList.getLength(); i++) {
+                Node nNode = nList.item(i);
+                if (nNode.getNodeType() == Node.ELEMENT_NODE) {
+                    Element eElement = (Element) nNode;
+                    System.out.println(eElement.getElementsByTagName("title").item(0).getTextContent() + "\n");
+                    if (eElement.getElementsByTagName("content:encoded").item(0) == null) {
+                        System.out.println("\t" + eElement.getElementsByTagName("description").item(0).getTextContent());
+                    } else {
+                        System.out.println("\t" + eElement.getElementsByTagName("content:encoded").item(0).getTextContent());
+                    }
+                    System.out.println("\t\t-Autor-Autores: " + eElement.getElementsByTagName("dc:creator").item(0).getTextContent());
+                    System.out.println("\t\t\t-Link de la publicación: " + eElement.getElementsByTagName("link").item(0).getTextContent());
+                    System.out.println("\n\n");
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+
+    }
+
+
+}

--- a/rss-dom/MGGomez/src/main/java/Main.java
+++ b/rss-dom/MGGomez/src/main/java/Main.java
@@ -1,0 +1,6 @@
+public class Main {
+    public static void main(String[] args) {
+        Documento doc = new Documento();
+        doc.leerDocumento();
+    }
+}


### PR DESCRIPTION
Un procesado sencillo del rss de noticias más leídas de El País, destacando los datos más habituales, como son el titular, la entradilla y los autores, todo ello usando las librerías de DOM Parse. 